### PR TITLE
Fix cli crash on resize

### DIFF
--- a/scripts/smbcmp
+++ b/scripts/smbcmp
@@ -88,7 +88,12 @@ def single_view_main(stdscr, args):
         if not empty:
             last_packet = tbuf.get_packet()[1]
 
-        k = stdscr.getkey()
+        k = None
+        try:
+            k = stdscr.getkey()
+        except curses.error:
+            pass
+
         if k == 'q':
             return
 
@@ -168,7 +173,11 @@ def diff_view_main(stdscr, args):
             last_lpacket = lbuf.get_packet()[1]
             last_rpacket = rbuf.get_packet()[1]
 
-        k = stdscr.getkey()
+        k = None
+        try:
+            k = stdscr.getkey()
+        except curses.error:
+            pass
         if k == 'q':
             return
 


### PR DESCRIPTION
When resizing on a mac, `getkey` would raise exceptions:

```
Traceback (most recent call last):
  File "scripts/smbcmp", line 458, in <module>
    main()
  File "scripts/smbcmp", line 33, in main
    curses.wrapper(diff_view_main, args)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/curses/__init__.py", line 105, in wrapper
    return func(stdscr, *args, **kwds)
  File "scripts/smbcmp", line 177, in diff_view_main
    k = stdscr.getkey()
_curses.error: no input
```