### PR TITLE
Fix crash when no config file present

### DIFF
--- a/smbcmp/common.py
+++ b/smbcmp/common.py
@@ -40,8 +40,9 @@ CONF.add_section('global')
 CRYPTO_KEY = {}
 
 
-def load_config(fn):
-    CONF.read(fn)
+def load_config(config_path):
+    if config_path is not None:
+        CONF.read(config_path)
 
     def k(name, default):
         KEY[name] = CONF['global'].get('key_'+name, default)
@@ -653,6 +654,8 @@ def parse_args(gui=False):
         load_config(args.config)
     elif os.path.exists(DEFAULT_CONFIG):
         load_config(DEFAULT_CONFIG)
+    else:
+        load_config(None)
 
     wireshark_checks(args)
     load_crypto_keys(args)


### PR DESCRIPTION
When using smbcli for the first time and attempting to navigate through packets, it crashes when attempting to read the value of `rwin_next` as the `load_config` function never loads `KEY` with the default config values

```
Traceback (most recent call last):
  File "/Users/user/smbcmp/scripts/smbcmp", line 434, in <module>
    main()
  File "/Users/user/smbcmp/scripts/smbcmp", line 33, in main
    curses.wrapper(diff_view_main, args)
  File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/curses/__init__.py", line 94, in wrapper
    return func(stdscr, *args, **kwds)
  File "/Users/user/smbcmp/scripts/smbcmp", line 175, in diff_view_main
    elif k == smbcmp.KEY['rwin_next']:
KeyError: 'rwin_next'
```