### PR TITLE
Feature Request - Show host information on packet diff screen

### DIFF
--- a/smbcmp/common.py
+++ b/smbcmp/common.py
@@ -213,10 +213,26 @@ def smb_summaries(pcap):
     cmd += ['-r', pcap, TSHARK_FILTER_FLAG, '!browser && (smb||smb2)']
     out = subprocess.check_output(cmd).decode('utf-8')
     pkts = {}
+
+    ip_map = {
+        '192.168.123.22': 'A',
+        '192.168.123.1': 'Relay',
+        '192.168.123.4': 'C'
+    };
+
     for line in out.split('\n'):
         m = re.match(r'''\s*(\d+).+?SMB2?\s*\d+\s*(.+)''', line)
+        ips = re.match(r'''.* (\d+\.\d+\.\d+\.\d+) → (\d+\.\d+\.\d+\.\d+).*''', line)
+        ip_info = ""
+
+        if ips:
+            ip_1 = ip_map.get(ips.group(1), ips.group(1))
+            ip_2 = ip_map.get(ips.group(2), ips.group(2))
+            ip_info = ip_1 + " -> " + ip_2 + ": "
+
         if m:
-            pkts[int(m.group(1))] = m.group(2)
+            pkts[int(m.group(1))] = ip_info + m.group(2)
+
     return pkts
 
 


### PR DESCRIPTION
smbcmp is great tool for comparing packets between two hosts, but is harder to use when multiple hosts are involved.
This PR acts as an initial feature request/proposal to smbcmp, but isn't production ready :+1:

### Example

Showing the src/dst fields with human readable/aliased host names:

![image](https://user-images.githubusercontent.com/1271782/149600669-02ba3043-523a-44c5-b199-67c2d918a93e.png)
